### PR TITLE
Deploy to prod

### DIFF
--- a/_project_docs/sample-profiles.yml
+++ b/_project_docs/sample-profiles.yml
@@ -1,0 +1,16 @@
+dbt_training:
+  target: dev
+  outputs:
+    dev:
+      type: clickhouse
+      schema: dbt_zduhovic
+      user: default
+      host: localhost
+      port: 8123
+    prod:
+      type: clickhouse
+      schema: dbt_prod
+      user: default
+      host: localhost
+      port: 8123
+  target: dev

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,7 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 seeds:
   dbt_training:
+    +schema: staging
     sale_dates:
       +column_types:
         SALE_DATE: date
@@ -38,9 +39,11 @@ models:
     # Config indicated by + and applies to all files under models/example/
     staging:
       +materialized: view
+      +schema: staging
     intermediate:
       +materialized: ephemeral
     marts:
       +materialized: table
+      +schema: marts
       +tags:
         - p1

--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {{ generate_schema_name_for_env(custom_schema_name, node) }}
+{%- endmacro %}

--- a/profiles.yml
+++ b/profiles.yml
@@ -7,3 +7,10 @@ dbt_training:
       user: default
       host: localhost
       port: 8123
+    prod:
+      type: clickhouse
+      schema: dbt_prod
+      user: default
+      host: localhost
+      port: 8123
+  target: dev


### PR DESCRIPTION
Deploy to Production

### Summary
Deploy current project to Production

### Details
Add `prod` target to `sample-profiles.yml`
`get_custom_schema.sql` - Uses the built-in macros `generate_schema_name` and `generate_schema_name_for_env`
   * Will result in all models being deployed to a `target` schema in non-prod environments (ex. `dev`, `qa`)
   * If `target` =  `prod` all models will be deployed to the individual custom schemas (ex. `staging`, `mart`)

Confirmed ability to deploy to `prod`.

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Target](https://docs.getdbt.com/reference/dbt-jinja-functions/target)
[Using Custom Schemas](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas)

